### PR TITLE
Docker registry with external index is never standalone

### DIFF
--- a/endpoints/index_defaults.js
+++ b/endpoints/index_defaults.js
@@ -16,6 +16,7 @@ module.exports = function(config, redis, logger) {
         fn: function(req, res, next) {
           // TODO: pass through to the actual registry??
     	    res.setHeader('X-Docker-Registry-Version', '0.8.0');
+    	    res.setHeader('X-Docker-Registry-Standalone', 'false');
     	    res.send(200);
           next();
         }
@@ -31,6 +32,7 @@ module.exports = function(config, redis, logger) {
         fn: function(req, res, next) {
           // TODO: pass through to the actual registry??
     	    res.setHeader('X-Docker-Registry-Version', '0.8.0');
+    	    res.setHeader('X-Docker-Registry-Standalone', 'false');
     	    res.send(200);
           next();
         }


### PR DESCRIPTION
As a registry with an external index it should not be considered standalone. Docker defaults to standalone is the header is not returned. This fixes a problem with running the registry and index over SSL.
