### PR TITLE
using links to enforce start order

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -7,6 +7,9 @@ redis:
 
 registry:
   image: ekristen/docker-index-registry:0.9.0
+  links:
+    - redis:redis
+    - index:index
   ports:
     - 5000:5000
   environment:


### PR DESCRIPTION
to make sure containers are started in the right order, using the links/dependency mechanism.

redis : no dependency
index: depends on redis
registry: depends on index and redis
nginx: depends on registry and index